### PR TITLE
DR2-1376 Use general eventbridge rule

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -37,7 +37,7 @@ class Lambda extends RequestStreamHandler {
   case class Detail(slackMessage: String)
 
   private def sendToSlack(slackMessage: String): IO[PutEventsResponse] =
-    eventBridgeClient.publishEventToEventBridge(getClass.getName, "DR2DevMessage", Detail(slackMessage))
+    eventBridgeClient.publishEventToEventBridge(getClass.getName, "DR2Message", Detail(slackMessage))
 
   override def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
     val rawInput: String = Source.fromInputStream(input).mkString


### PR DESCRIPTION
This will send this message to the `da-dr2-notifications` channel
instead of `da-dr2-dev-notifications`
