### PR TITLE
Stop showing changed titles and descriptions in Slack

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -165,30 +165,28 @@ class Lambda extends RequestStreamHandler {
       folderUpdateRequest: EntityWithUpdateEntityRequest
   ): String = {
     val entity: Entity = folderUpdateRequest.entity
-    val firstLine: String = generateSlackMessageFirstLine(preservicaUrl, entity)
+    val firstLineOfMsg: String = generateSlackMessageFirstLine(preservicaUrl, entity, messageWithNewLine = false)
     val updateEntityRequest = folderUpdateRequest.updateEntityRequest
 
-    def generateMessage(name: String, oldString: String, newString: String) =
-      s"""*Old $name*: $oldString
-         |*New $name*: $newString""".stripMargin
-
     val titleUpdates = Option.when(entity.title.getOrElse("") != updateEntityRequest.title)(
-      generateMessage("title", entity.title.getOrElse(""), updateEntityRequest.title)
+      "Title has changed"
     )
     val descriptionUpdates = Option.when(updateEntityRequest.descriptionToChange.isDefined)(
-      generateMessage("description", entity.description.getOrElse(""), updateEntityRequest.descriptionToChange.get)
+      "Description has changed"
     )
 
-    firstLine ++ List(titleUpdates, descriptionUpdates).flatten.mkString("\n")
+    firstLineOfMsg ++ s"*${List(titleUpdates, descriptionUpdates).flatten.mkString(" and ")}*"
   }
 
-  private def generateSlackMessageFirstLine(preservicaUrl: String, entity: Entity) = {
+  private def generateSlackMessageFirstLine(preservicaUrl: String, entity: Entity, messageWithNewLine: Boolean = true) = {
     val entityTypeShort = entity.entityType
       .map(_.entityTypeShort)
       .getOrElse("IO") // We need a default and Preservica don't validate the entity type in the url
     val entityUrl = s"$preservicaUrl/explorer/explorer.html#properties:$entityTypeShort&${entity.ref}"
-    s""":preservica: Entity <$entityUrl|${entity.ref}> has been updated
+    val firstLineOfMsg = s":preservica: Entity <$entityUrl|${entity.ref}> has been updated: "
+    val firstLineOfMsgWithNewLine = s"""$firstLineOfMsg
                                   |""".stripMargin
+    if (messageWithNewLine) firstLineOfMsgWithNewLine else firstLineOfMsg
   }
 
   private def getFolderRowsSortedByParentPath(

--- a/src/test/scala/uk/gov/nationalarchives/testUtils/ExternalServicesTestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/testUtils/ExternalServicesTestUtils.scala
@@ -413,16 +413,13 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
           val entityTypeShort = entity.entityType.get.entityTypeShort
           val url = "http://localhost:9001/explorer/explorer.html#properties"
           val messageFirstLine =
-            s":preservica: Entity <$url:$entityTypeShort&${entity.ref}|${entity.ref}> has been updated\n"
+            s":preservica: Entity <$url:$entityTypeShort&${entity.ref}|${entity.ref}> has been updated: "
           val expectedMessage = if (oldTitle != newTitle && updateRequest.descriptionToChange.isEmpty) {
-            messageFirstLine +
-              s"*Old title*: $oldTitle\n*New title*: $newTitle"
+            messageFirstLine + "*Title has changed*"
           } else if (oldTitle == newTitle && updateRequest.descriptionToChange.isDefined) {
-            messageFirstLine +
-              s"*Old description*: $oldDescription\n*New description*: $newDescription"
+            messageFirstLine + "*Description has changed*"
           } else {
-            messageFirstLine +
-              s"*Old title*: $oldTitle\n*New title*: $newTitle\n*Old description*: $oldDescription\n*New description*: $newDescription"
+            messageFirstLine + "*Title has changed and Description has changed*"
           }
           sentMessages.count(_ == expectedMessage) should equal(1)
         }


### PR DESCRIPTION
Instead, it will just post that a title/description has changed